### PR TITLE
[RF] TemplateFlow and brain_mask

### DIFF
--- a/extract_timeseries_tar.py
+++ b/extract_timeseries_tar.py
@@ -125,7 +125,7 @@ def fetch_atlas_path(atlas_name, description_keywords, atlas_path, template):
     return sklearn.utils.Bunch(maps=img_path, labels=labels, type=atlas_type)
 
 
-def generate_templateflow_parameters(cur_atlas_meta, file_type, resolution, description_keywords):
+def generate_templateflow_parameters(cur_atlas_meta, file_type, description_keywords):
     """
     Generate a dictionary containing parameters for TemplateFlow quiery.
 

--- a/extract_timeseries_tar.py
+++ b/extract_timeseries_tar.py
@@ -127,7 +127,7 @@ def fetch_atlas_path(atlas_name, template, resolution, description_keywords):
     return sklearn.utils.Bunch(maps=img_path, labels=labels, type=atlas_type)
 
 
-def generate_templateflow_parameters(cur_atlas_meta, file_type, description_keywords):
+def generate_templateflow_parameters(cur_atlas_meta, file_type, resolution, description_keywords):
     """
     Generate a dictionary containing parameters for TemplateFlow quiery.
 

--- a/extract_timeseries_tar.py
+++ b/extract_timeseries_tar.py
@@ -229,18 +229,9 @@ def create_timeseries_root_dir(file_entitiles, output_dir):
 def download_atlases():
     """Download all atlases using ATLAS_METADATA."""
 
-    for atlas_name in ATLAS_METADATA.keys():
-        cur_atlas_meta = ATLAS_METADATA[atlas_name].copy()
-        if cur_atlas_meta['source'] == "templateflow":
-            for template in cur_atlas_meta['templates']:
-                for resolution in cur_atlas_meta['resolutions']:
-                    for dimension in cur_atlas_meta['dimensions']:
-                        description_keywords = {"dimension": dimension}
-                        print(f"-- {atlas_name}.{template}.{resolution}mm.{dimension}dim --")
-                        atlas = fetch_atlas_path(atlas_name,
-                                              resolution=resolution,
-                                              template=template,
-                                              description_keywords=description_keywords)
+    for template in templateflow.api.templates():
+        if "MNI152" in template:
+            templateflow.api.get(template)
 
 def bidsish_timeseries_file_name(file_entitiles, layout, atlas_name, dimension):
     """Create a BIDS-like file name to save extracted timeseries as tsv."""

--- a/extract_timeseries_tar.py
+++ b/extract_timeseries_tar.py
@@ -81,7 +81,7 @@ def update_templateflow_path(atlas_name, atlas_path):
     
     # by default, it uses `~/.cache/templateflow/`
     if atlas_source == "templateflow":
-        templateflow.conf.TF_HOME = os.path.join(os.getenv("HOME"), ".cache", "templateflow")
+        templateflow.conf.TF_HOME = templateflow.conf.TF_DEFAULT_HOME
         templateflow.conf.init_layout()
     # otherwise use user defined atlas path
     elif atlas_source == "user_define":

--- a/extract_timeseries_tar.py
+++ b/extract_timeseries_tar.py
@@ -129,8 +129,6 @@ def fetch_atlas_path(atlas_name, template, resolution, description_keywords):
 
     img_parameters = generate_templateflow_parameters(cur_atlas_meta, "atlas", resolution, description_keywords)
     label_parameters = generate_templateflow_parameters(cur_atlas_meta, "label", resolution, description_keywords)
-    print(img_parameters)
-    print(label_parameters)
     img_path = templateflow.api.get(template, raise_empty=True, **img_parameters)
     img_path = str(img_path)
     label_path = templateflow.api.get(template, raise_empty=True, **label_parameters)

--- a/extract_timeseries_tar.py
+++ b/extract_timeseries_tar.py
@@ -18,68 +18,162 @@ import sklearn.utils
 import bids
 
 ATLAS_METADATA = {
-    'difumo': {'type': "dynamic",
-               'dimensions': [64, 128, 256, 512, 1024],
-               'resolutions': [2, 3],
-               'label_idx': 1,
-               'fetcher': "nilearn.datasets.fetch_atlas_difumo(dimension={dimension}, resolution_mm={resolution}, data_dir=\"{atlas_path}\")"},
-    'segmented_difumo': {'type': "dynamic",
-                         'dimensions': [64, 128, 256, 512, 1024],
-                         'resolutions': [2, 3],
-                         'fetcher': "segmented_difumo_fetcher(dimension={dimension}, resolution_mm={resolution}, atlas_path=\"{atlas_path}\")"},
-}
+    # 'schaefer': {
+    #     'source': "templateflow",
+    #     'templates' : ['MNI152NLin2009cAsym', 'MNI152NLin6Asym'],
+    #     'resolutions': ["01", "02"],
+    #     'atlas': 'Schaefer2018',
+    #     'description_pattern': "{dimension}Parcels{network}Networks",
+    #     'dimensions': [100, 200, 300, 400, 500, 600, 800, 1000],
+    #     'networks': [7, 17],
+    #     'atlas_parameters': ['resolution', 'description'],
+    #     'label_parameters': ['description'],
+    #     },
+    'schaefer7': {
+        'source': "templateflow",
+        'templates' : ['MNI152NLin2009cAsym', 'MNI152NLin6Asym'],
+        'resolutions': ["01", "02"],
+        'atlas': 'Schaefer2018',
+        'description_pattern': "{dimension}Parcels7Networks",
+        'dimensions': [100, 200, 300, 400, 500, 600, 800, 1000],
+        'atlas_parameters': ['resolution', 'description'],
+        'label_parameters': ['description'],
+        },
+    'difumo': {
+        'source': "templateflow",
+        'templates' : ['MNI152NLin2009cAsym', 'MNI152NLin6Asym'],
+        'resolutions': ["02", "03"],
+        'atlas': 'DifuMo',
+        'description_pattern': "{dimension}dimensions",
+        'dimensions': [64, 128, 256, 512, 1024],
+        'atlas_parameters': ['resolution', 'description'],
+        'label_parameters': ['resolution','description'],
+        },
+    "segmented_difumo": {
+        'source': "user_define",
+        'templates' : ['MNI152NLin2009cAsym'],
+        'resolutions': ["02", "03"],
+        'atlas': 'DifuMo',
+        'description_pattern': "{dimension}dimensionsSegmented",
+        'dimensions': [64, 128, 256, 512, 1024],
+        'atlas_parameters': ['resolution', 'description'],
+        'label_parameters': ['resolution','description'],
+        },
+    }
 
-#TODO: mask data using subject mask
-#TODO: wait you PR before making a standalone tool (templateflow downloading, confound parameters loading)
-#TODO: QC timeseries https://github.com/SIMEXP/mapsmasker_benchmark/blob/main/mapsmasker_benchmark/main.py 
-def segmented_difumo_fetcher(atlas_path, dimension=64, resolution_mm=3):
+#TODO: QC timeseries https://github.com/SIMEXP/mapsmasker_benchmark/blob/main/mapsmasker_benchmark/main.py
+def fetch_atlas_path(atlas_name, description_keywords, atlas_path, template):
+    """
+    Generate a dictionary containing parameters for TemplateFlow quiery.
 
-    templateflow.conf.TF_HOME = pathlib.Path(atlas_path)
-    templateflow.conf.init_layout()
-    templateflow.conf.update(local=True)
+    Parameters
+    ----------
+    atlas_name : str
+        Atlas name. Must be a key in ATLAS_METADATA.
 
-    img_path = str(templateflow.api.get("MNI152NLin2009cAsym", atlas="DiFuMo",
-                                        desc=f"{dimension}dimensionsSegmented", resolution=f"0{resolution_mm}", extension=".nii.gz"))
-    label_path = str(templateflow.api.get("MNI152NLin2009cAsym", atlas="DiFuMo",
-                                          desc=f"{dimension}dimensionsSegmented", resolution=f"0{resolution_mm}", extension=".tsv"))
+    description_keywords : dict
+        Keys and values to fill in description_pattern.
+        For valid keys check relevant ATLAS_METADATA[atlas_name]['description_pattern'].
+
+    atlas_path : str
+        Path to self-defined atlas collection in TemplateFlow competable naming convention.
+
+    template : str
+        TemplateFlow template name.
+
+    Return
+    ------
+    sklearn.utils.Bunch
+        Containing the following fields:
+
+        maps : str
+            Path to atlas map.
+
+        labels : pandas.DataFrame
+            The corresponding pandas dataframe of the atlas
+
+        type : str
+            'dseg' (for NiftiLabelsMasker) or 'probseg' (for NiftiMapsMasker)
+    """
+
+    cur_atlas_meta = ATLAS_METADATA[atlas_name]
+    if cur_atlas_meta['source'] != "templateflow":
+        templateflow.conf.TF_HOME = pathlib.Path(atlas_path)
+        templateflow.conf.init_layout()
+        templateflow.conf.update(local=True)
+    img_parameters = generate_templateflow_parameters(cur_atlas_meta, "atlas", description_keywords)
+    label_parameters = generate_templateflow_parameters(cur_atlas_meta, "label", description_keywords)
+
+    img_path = str(templateflow.api.get(template, **img_parameters))
+    label_path = str(templateflow.api.get(template, **label_parameters))
     labels = pd.read_csv(label_path, delimiter="\t")
-    labels = (labels['Region'].astype(str) + ". " +
-              labels['Difumo_names']).values.tolist()
+    # labels = (labels['Region'].astype(str) + ". " +
+    #           labels['Difumo_names']).values.tolist()
+    atlas_type = img_path.split('_')[-1].split('.nii.gz')[0]
+    return sklearn.utils.Bunch(maps=img_path, labels=labels, type=atlas_type)
 
-    return sklearn.utils.Bunch(maps=img_path, labels=labels)
+
+def generate_templateflow_parameters(cur_atlas_meta, file_type, resolution, description_keywords):
+    """
+    Generate a dictionary containing parameters for TemplateFlow quiery.
+
+    Parameters
+    ----------
+    cur_atlas_meta : dict
+        The current TemplateFlow competable atlas metadata.
+    file_type : str {'atlas', 'label'}
+        Generate parameters to quiry atlas or label.
+    description_keywords : dict
+        Keys and values to fill in description_pattern.
+        For valid keys check relevant ATLAS_METADATA[atlas_name]['description_pattern'].
+
+    Return
+    ------
+    dict
+        A dictionary containing parameters to pass to a templateflow query.
+    """
+    description = cur_atlas_meta['description_pattern'].format(**description_keywords)
+
+    parameters_ = {key: None for key in cur_atlas_meta[f'{file_type}_parameters']}
+    parameters_.update({'atlas': cur_atlas_meta['atlas'], 'extension': ".nii.gz"})
+    if parameters_.get('resolution', False):
+        parameters_['resolution'] = resolution
+    if parameters_.get('description', False):
+        parameters_['description'] = description
+    return parameters_
 
 
-def create_atlas_masker(atlas_name, atlas_path, dimension, resolution, nilearn_cache=""):
-    """Create masker of all dimensions and resolutions given metadata."""
-    if atlas_name not in ATLAS_METADATA.keys():
-        raise ValueError("{} not defined!".format(atlas_name))
-    curr_atlas = ATLAS_METADATA[atlas_name]
-    curr_atlas['name'] = atlas_name
+def create_atlas_masker(atlas_name, description_keywords, atlas_path, template='MNI152NLin2009cAsym', nilearn_cache=""):
+    """Create masker given metadata.
 
-    atlas = eval(curr_atlas['fetcher'].format(
-        atlas_path=atlas_path, dimension=dimension, resolution=resolution))
-    if curr_atlas['type'] == "static":
-        masker = nilearn.input_data.NiftiLabelsMasker(
-            atlas.maps, detrend=True)
-    elif curr_atlas['type'] == "dynamic":
-        masker = nilearn.input_data.NiftiMapsMasker(
-            atlas.maps, detrend=True)
+    Parameters
+    ----------
+    atlas_name : str
+        Atlas name. Must be a key in ATLAS_METADATA.
+
+    description_keywords : dict
+        Keys and values to fill in description_pattern.
+        For valid keys check relevant ATLAS_METADATA[atlas_name]['description_pattern'].
+
+    atlas_path : str
+        Path to self-defined atlas collection in TemplateFlow competable naming convention.
+
+    template : str
+        TemplateFlow template name.
+
+    """
+    atlas = fetch_atlas_path(atlas_name,
+                             template=template,
+                             description_keywords=description_keywords,
+                             atlas_path=atlas_path)
+
+    if atlas.type == 'dseg':
+        masker = nilearn.input_data.NiftiLabelsMasker(atlas.maps, detrend=True)
+    elif atlas.type == 'probseg':
+        masker = nilearn.input_data.NiftiMapsMasker(atlas.maps, detrend=True)
     if nilearn_cache:
         masker = masker.set_params(memory=nilearn_cache, memory_level=1)
-    # fill atlas info
-    curr_atlas[dimension] = {'masker': masker}
-    if isinstance(atlas.labels[0], tuple) | isinstance(atlas.labels[0], list):
-        if isinstance(atlas.labels[0][curr_atlas['label_idx']], bytes):
-            labels = [label[curr_atlas['label_idx']].decode()
-                      for label in atlas.labels]
-        else:
-            labels = [label[curr_atlas['label_idx']] for label in atlas.labels]
-    else:
-        if isinstance(atlas.labels[0], bytes):
-            labels = [label.decode() for label in atlas.labels]
-        else:
-            labels = [label for label in atlas.labels]
-
+    labels = list(range(1, atlas.labels.shape[0] + 1))
     return masker, labels
 
 
@@ -138,6 +232,8 @@ if __name__ == '__main__':
     dataset_name = args.dataset_name
     output_root_dir = args.output_dir
 
+    template = 'MNI152NLin2009cAsym'
+
     layout = bids.BIDSLayout(data_path, config=['bids', 'derivatives'])
     subject_list = layout.get(return_type='id', target='subject')
 
@@ -152,17 +248,25 @@ if __name__ == '__main__':
             # Note from AB
             # if multiple run, use run 2
             # if multiple session, use ses 1
-            fmri = layout.get(return_type='type', subject=subject, space='MNI152NLin2009cAsym',
+            fmri = layout.get(return_type='type', subject=subject, space=template,
                               desc='preproc', suffix='bold', extension='nii.gz')
+            brain_mask = layout.get(return_type='type', subject=subject, space=template,
+                                    desc='brain', suffix='mask', extension='nii.gz')
+            # TODO: check if brain_mask and fmri always come in pairs
+            # according to doc, desc-preproc_bold and desc-brain_mask should come in pairs
             for ii in range(len(fmri)):
                 file_entitiles = fmri[ii].entities
                 timeseries_root_dir = create_timeseries_root_dir(
                     file_entitiles, output_dir)
                 for dimension in ATLAS_METADATA[atlas_name]['dimensions']:
                     for resolution in ATLAS_METADATA[atlas_name]['resolutions']:
-                        print(f"\t dim{dimension} - res0{resolution}")
-                        masker, labels = create_atlas_masker(
-                            atlas_name, atlas_path, dimension, resolution)
+                        print(f"\t dim{dimension} - {resolution}")
+                        description_keywords = {'dimension': dimension,
+                                                'resolution': resolution}
+                        masker, labels = create_atlas_masker(atlas_name,
+                                                             template,
+                                                             description_keywords,
+                                                             atlas_path)
                         output_filename = bidsish_timeseries_file_name(
                             file_entitiles, layout, atlas_name, dimension)
                         confounds, sample_mask = nilearn.interfaces.fmriprep.load_confounds(fmri[ii].path,
@@ -171,6 +275,7 @@ if __name__ == '__main__':
                                                                                             motion='basic', wm_csf='basic', global_signal='basic',
                                                                                             scrub=5, fd_threshold=0.5, std_dvars_threshold=None,
                                                                                             demean=True)
+                        masker.set_parameters(mask_img=brain_mask[ii].path)
                         timeseries = masker.fit_transform(
                             fmri[ii].path, confounds=confounds, sample_mask=sample_mask)
                         # Estimating connectomes

--- a/extract_timeseries_tar.py
+++ b/extract_timeseries_tar.py
@@ -306,10 +306,6 @@ if __name__ == '__main__':
             update_templateflow_path(atlas_name, atlas_path)
             for subject in subject_list:
                 print(f"sub-{subject}")
-                # TODO: loop through all
-                # Note from AB
-                # if multiple run, use run 2
-                # if multiple session, use ses 1
                 fmri = layout.get(return_type='type', subject=subject, space=template,
                                   desc='preproc', suffix='bold', extension='nii.gz')
                 brain_mask = layout.get(return_type='type', subject=subject, space=template,

--- a/extract_timeseries_tar.py
+++ b/extract_timeseries_tar.py
@@ -40,21 +40,22 @@ ATLAS_METADATA = {
         'atlas_parameters': ['resolution', 'desc'],
         'label_parameters': ['desc'],
         },
-    'difumo': {
-        'source': "templateflow",
-        'templates' : ['MNI152NLin2009cAsym', 'MNI152NLin6Asym'],
-        'resolutions': [2, 3],
-        'atlas': 'DifuMo',
-        'description_pattern': "{dimension}dimensions",
-        'dimensions': [64, 128, 256, 512, 1024],
-        'atlas_parameters': ['resolution', 'desc'],
-        'label_parameters': ['resolution','desc'],
-        },
+    #TODO: fix upstream issues with difumo
+    # 'difumo': {
+    #     'source': "templateflow",
+    #     'templates' : ['MNI152NLin2009cAsym', 'MNI152NLin6Asym'],
+    #     'resolutions': [2, 3],
+    #     'atlas': 'DiFuMo',
+    #     'description_pattern': "{dimension}dimensions",
+    #     'dimensions': [64, 128, 256, 512, 1024],
+    #     'atlas_parameters': ['resolution', 'desc'],
+    #     'label_parameters': ['resolution','desc'],
+    #     },
     "segmented_difumo": {
         'source': "user_define",
         'templates' : ['MNI152NLin2009cAsym'],
         'resolutions': [2, 3],
-        'atlas': 'DifuMo',
+        'atlas': 'DiFuMo',
         'description_pattern': "{dimension}dimensionsSegmented",
         'dimensions': [64, 128, 256, 512, 1024],
         'atlas_parameters': ['resolution', 'desc'],
@@ -73,6 +74,21 @@ LOAD_CONFOUNDS_PARAMS = {
     'demean': True
 }
 
+def update_templateflow_path(atlas_name, atlas_path):
+    """Update local templateflow path, if needed."""
+
+    atlas_source = ATLAS_METADATA[atlas_name]['source']
+    
+    # by default, it uses `~/.cache/templateflow/`
+    if atlas_source == "templateflow":
+        templateflow.conf.TF_HOME = os.path.join(os.getenv("HOME"), ".cache", "templateflow")
+        templateflow.conf.init_layout()
+    # otherwise use user defined atlas path
+    elif atlas_source == "user_define":
+        templateflow.conf.TF_HOME = pathlib.Path(atlas_path)
+        templateflow.conf.init_layout()
+    else:
+        pass
 
 #TODO: QC timeseries https://github.com/SIMEXP/mapsmasker_benchmark/blob/main/mapsmasker_benchmark/main.py
 def fetch_atlas_path(atlas_name, template, resolution, description_keywords):
@@ -111,19 +127,18 @@ def fetch_atlas_path(atlas_name, template, resolution, description_keywords):
 
     cur_atlas_meta = ATLAS_METADATA[atlas_name].copy()
 
-    if cur_atlas_meta['source'] != "templateflow":
-        templateflow.conf.init_layout()
-
     img_parameters = generate_templateflow_parameters(cur_atlas_meta, "atlas", resolution, description_keywords)
     label_parameters = generate_templateflow_parameters(cur_atlas_meta, "label", resolution, description_keywords)
+    print(img_parameters)
+    print(label_parameters)
     img_path = templateflow.api.get(template, raise_empty=True, **img_parameters)
     img_path = str(img_path)
     label_path = templateflow.api.get(template, raise_empty=True, **label_parameters)
-
     labels = pd.read_csv(label_path, delimiter="\t")
     # labels = (labels['Region'].astype(str) + ". " +
     #           labels['Difumo_names']).values.tolist()
     atlas_type = img_path.split('_')[-1].split('.nii.gz')[0]
+    
     return sklearn.utils.Bunch(maps=img_path, labels=labels, type=atlas_type)
 
 
@@ -211,6 +226,21 @@ def create_timeseries_root_dir(file_entitiles, output_dir):
 
     return timeseries_root_dir
 
+def download_atlases():
+    """Download all atlases using ATLAS_METADATA."""
+
+    for atlas_name in ATLAS_METADATA.keys():
+        cur_atlas_meta = ATLAS_METADATA[atlas_name].copy()
+        if cur_atlas_meta['source'] == "templateflow":
+            for template in cur_atlas_meta['templates']:
+                for resolution in cur_atlas_meta['resolutions']:
+                    for dimension in cur_atlas_meta['dimensions']:
+                        description_keywords = {"dimension": dimension}
+                        print(f"-- {atlas_name}.{template}.{resolution}mm.{dimension}dim --")
+                        atlas = fetch_atlas_path(atlas_name,
+                                              resolution=resolution,
+                                              template=template,
+                                              description_keywords=description_keywords)
 
 def bidsish_timeseries_file_name(file_entitiles, layout, atlas_name, dimension):
     """Create a BIDS-like file name to save extracted timeseries as tsv."""
@@ -239,6 +269,10 @@ def get_parser():
     )
 
     parser.add_argument(
+        "--download-only", required=False, action='store_true', help="Download only the atlases, for HPC with firewalled nodes to download templateflow data in the login node.",
+    )
+
+    parser.add_argument(
         "-o", "--output-dir", required=False, default=".", help="Output directory (default: \"./\")",
     )
 
@@ -251,66 +285,69 @@ if __name__ == '__main__':
     data_path = args.input_dir
     atlas_path = args.atlas_path
     dataset_name = args.dataset_name
+    download_only = args.download_only
     output_root_dir = args.output_dir
 
-    templateflow.conf.TF_HOME = pathlib.Path(atlas_path)
-    templateflow.conf.update(local=True)
+    if download_only:
+        print("Download only.")
+        download_atlases()
+    else:
+        template = 'MNI152NLin2009cAsym'
+        resolution = "02"
 
-    template = 'MNI152NLin2009cAsym'
-    resolution = "02"
+        layout = bids.BIDSLayout(data_path, config=['bids', 'derivatives'])
+        subject_list = layout.get(return_type='id', target='subject')
 
-    layout = bids.BIDSLayout(data_path, config=['bids', 'derivatives'])
-    subject_list = layout.get(return_type='id', target='subject')
+        for atlas_name in ATLAS_METADATA.keys():
+            print("-- {} --".format(atlas_name))
+            dataset_title = f"dataset-{dataset_name}_atlas-{atlas_name}"
+            output_dir = os.path.join(output_root_dir, dataset_title)
+            os.makedirs(output_dir, exist_ok=True)
+            update_templateflow_path(atlas_name, atlas_path)
+            for subject in subject_list:
+                print(f"sub-{subject}")
+                # TODO: loop through all
+                # Note from AB
+                # if multiple run, use run 2
+                # if multiple session, use ses 1
+                fmri = layout.get(return_type='type', subject=subject, space=template,
+                                  desc='preproc', suffix='bold', extension='nii.gz')
+                brain_mask = layout.get(return_type='type', subject=subject, space=template,
+                                        desc='brain', suffix='mask', extension='nii.gz')
+                # TODO: check if brain_mask and fmri always come in pairs
+                # according to doc, desc-preproc_bold and desc-brain_mask should come in pairs
+                for ii in range(len(fmri)):
+                    file_entitiles = fmri[ii].entities
+                    timeseries_root_dir = create_timeseries_root_dir(
+                        file_entitiles, output_dir)
+                    for dimension in ATLAS_METADATA[atlas_name]['dimensions']:
+                        print(f"\tatlas {atlas_name}\tdim{dimension}")
+                        description_keywords = {"dimension": dimension}
+                        masker, labels = create_atlas_masker(
+                            atlas_name, description_keywords, template=template, resolution=resolution)
+                        output_filename = bidsish_timeseries_file_name(
+                            file_entitiles, layout, atlas_name, dimension)
+                        confounds, sample_mask = nilearn.interfaces.fmriprep.load_confounds(fmri[ii].path,
+                                                                                            **LOAD_CONFOUNDS_PARAMS)
+                        masker.set_params(mask_img=brain_mask[ii].path)
+                        timeseries = masker.fit_transform(
+                            fmri[ii].path, confounds=confounds, sample_mask=sample_mask)
+                        # Estimating connectomes
+                        corr_measure = nilearn.connectome.ConnectivityMeasure(
+                            kind="correlation")
+                        connectome = corr_measure.fit_transform([timeseries])[0]
+                        # Save to file
+                        timeseries = pd.DataFrame(timeseries, columns=labels)
+                        timeseries.to_csv(os.path.join(timeseries_root_dir, output_filename), sep='\t', index=False)
+                        connectome = pd.DataFrame(
+                            connectome, columns=labels, index=labels)
+                        connectome.to_csv(
+                            os.path.join(timeseries_root_dir, output_filename.replace("timeseries", "connectome")), sep='\t')
 
-    for atlas_name in ATLAS_METADATA.keys():
-        print("-- {} --".format(atlas_name))
-        dataset_title = f"dataset-{dataset_name}_atlas-{atlas_name}"
-        output_dir = os.path.join(output_root_dir, dataset_title)
-        os.makedirs(output_dir, exist_ok=True)
-        for subject in subject_list:
-            print(f"sub-{subject}")
-            # TODO: loop through all
-            # Note from AB
-            # if multiple run, use run 2
-            # if multiple session, use ses 1
-            fmri = layout.get(return_type='type', subject=subject, space=template,
-                              desc='preproc', suffix='bold', extension='nii.gz')
-            brain_mask = layout.get(return_type='type', subject=subject, space=template,
-                                    desc='brain', suffix='mask', extension='nii.gz')
-            # TODO: check if brain_mask and fmri always come in pairs
-            # according to doc, desc-preproc_bold and desc-brain_mask should come in pairs
-            for ii in range(len(fmri)):
-                file_entitiles = fmri[ii].entities
-                timeseries_root_dir = create_timeseries_root_dir(
-                    file_entitiles, output_dir)
-                for dimension in ATLAS_METADATA[atlas_name]['dimensions']:
-                    print(f"\tatlas {atlas_name}\tdim{dimension}")
-                    description_keywords = {"dimension": dimension}
-                    masker, labels = create_atlas_masker(
-                        atlas_name, description_keywords, template=template, resolution=resolution)
-                    output_filename = bidsish_timeseries_file_name(
-                        file_entitiles, layout, atlas_name, dimension)
-                    confounds, sample_mask = nilearn.interfaces.fmriprep.load_confounds(fmri[ii].path,
-                                                                                        **LOAD_CONFOUNDS_PARAMS)
-                    masker.set_parameters(mask_img=brain_mask[ii].path)
-                    timeseries = masker.fit_transform(
-                        fmri[ii].path, confounds=confounds, sample_mask=sample_mask)
-                    # Estimating connectomes
-                    corr_measure = nilearn.connectome.ConnectivityMeasure(
-                        kind="correlation")
-                    connectome = corr_measure.fit_transform([timeseries])[0]
-                    # Save to file
-                    timeseries = pd.DataFrame(timeseries, columns=labels)
-                    timeseries.to_csv(os.path.join(timeseries_root_dir, output_filename), sep='\t', index=False)
-                    connectome = pd.DataFrame(
-                        connectome, columns=labels, index=labels)
-                    connectome.to_csv(
-                        os.path.join(timeseries_root_dir, output_filename.replace("timeseries", "connectome")), sep='\t')
-
-        # tar the dataset
-        tar_path = os.path.join(output_root_dir, f"{dataset_title}.tar.gz")
-        with tarfile.open(tar_path, "w:gz") as tar:
-            tar.add(output_dir, arcname=os.path.dirname(output_dir))
+            # tar the dataset
+            tar_path = os.path.join(output_root_dir, f"{dataset_title}.tar.gz")
+            with tarfile.open(tar_path, "w:gz") as tar:
+                tar.add(output_dir, arcname=os.path.dirname(output_dir))
 
 
 import pytest
@@ -321,6 +358,7 @@ def test_templateflow(tmpdir):
     resolution = 2
     templateflow.conf.TF_HOME = tmpdir
     templateflow.conf.update(local=True)
+    # schaefer test
     atlas_name = 'schaefer7'
     dimension = 100
     print(f"\tatlas {atlas_name}\tdim{dimension}")
@@ -334,3 +372,28 @@ def test_templateflow(tmpdir):
     masker, labels = create_atlas_masker(atlas_name, description_keywords)
     assert type(masker) == nilearn.input_data.NiftiLabelsMasker
     assert len(labels) == 100
+    # difumo test
+    ATLAS_METADATA['difumo'] = {
+        'source': "templateflow",
+        'templates' : ['MNI152NLin2009cAsym', 'MNI152NLin6Asym'],
+        'resolutions': [2, 3],
+        'atlas': 'DiFuMo',
+        'description_pattern': "{dimension}dimensions",
+        'dimensions': [64, 128, 256, 512, 1024],
+        'atlas_parameters': ['resolution', 'desc'],
+        'label_parameters': ['resolution','desc'],
+        },
+    atlas_name = 'difumo'
+    dimension = 64
+    print(f"\tatlas {atlas_name}\tdim{dimension}")
+    description_keywords = {"dimension": dimension, "resolution": resolution}
+    atlas = fetch_atlas_path(atlas_name,
+                                resolution=resolution,
+                                template=template,
+                                description_keywords=description_keywords)
+    assert atlas.maps.split('/')[-1] == 'tpl-MNI152NLin6Asym_res-02_atlas-DiFuMo_desc-64dimensions_probseg.nii.gz'
+    assert atlas.type == 'probseg'
+    masker, labels = create_atlas_masker(atlas_name, description_keywords)
+    assert type(masker) == nilearn.input_data.NiftiLabelsMasker
+    assert len(labels) == 64
+

--- a/fmriprep_script.sh
+++ b/fmriprep_script.sh
@@ -18,3 +18,4 @@ scp -r $SCRATCH/atlases $SLURM_TMPDIR/
 source /home/ltetrel/.virtualenvs/ts_extraction/bin/activate
 
 python3 /home/ltetrel/ccna_ts_extraction/extract_timeseries_tar.py -i $SLURM_TMPDIR/ukbb/derivatives/fmriprep/fmriprep/ --atlas-path $SLURM_TMPDIR/atlases --dataset-name ukbb -o $SLURM_TMPDIR
+exit 0

--- a/fmriprep_script.sh
+++ b/fmriprep_script.sh
@@ -18,4 +18,6 @@ scp -r $SCRATCH/atlases $SLURM_TMPDIR/
 source /home/ltetrel/.virtualenvs/ts_extraction/bin/activate
 
 python3 /home/ltetrel/ccna_ts_extraction/extract_timeseries_tar.py -i $SLURM_TMPDIR/ukbb/derivatives/fmriprep/fmriprep/ --atlas-path $SLURM_TMPDIR/atlases --dataset-name ukbb -o $SLURM_TMPDIR
+scp $SLURM_TMPDIR/*.tar.gz $SCRATCH/
+
 exit 0


### PR DESCRIPTION
- Add brain mask to the masker; **need to check if the returned results are paired with the functional data**
- Revise the atlas metadata to fit templateflow
- `create_atlas_masker` now only return one masker and the corresponding
label
- `fetch_atlas_path` to get templateflow compatible atlas files
- `generate_templateflow_parameters` parse metadata such as resolution
and dimensions, return keyword arguments for templateflow api

I tried to find a way to summarise templateflow file name entities and found there can be a lot of nuances with the `desc-` entity, hence I created `description_pattern` (see `'schaefer'`, currently commented out).
This is a big one and I am happy to discuss.